### PR TITLE
fix: remove redundant `calc()`

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -9,7 +9,7 @@
 
 .colorSchemeToggle {
   position: absolute;
-  top: calc(var(--mantine-spacing-xl));
+  top: var(--mantine-spacing-xl);
   right: var(--mantine-spacing-xl);
 
   @media (max-width: $mantine-breakpoint-sm) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified CSS variable usage in theme toggle styling to improve code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->